### PR TITLE
Support a hook for findOneAndUpdate

### DIFF
--- a/lib/relationship.js
+++ b/lib/relationship.js
@@ -22,29 +22,29 @@ module.exports = function Relationship(info) {
     schema.add(addition)
   }
 
-  function updateDependents(itsPath) {
-    return function(next) {
+  function updateDependents(itsPath, alwaysRemove) {
+    return function(doc, next) {
       var update = { }
       update[updateOp] = {}
-      update[updateOp][itsPath] = this._doc._id
+      update[updateOp][itsPath] = doc._id
 
       var remove = { }
       remove[removeOp] = {}
-      remove[removeOp][itsPath] = this._doc._id
+      remove[removeOp][itsPath] = doc._id
 
       var query = info.rules.iHaveMany
-        ? {_id: { $in: this._doc[myPath] }}
-        : {_id: this._doc[myPath]}
+        ? {_id: { $in: doc[myPath] }}
+        : {_id: doc[myPath]}
 
 
       async.parallel([
         function(onward) {
           info.instance.model(info.modelName).update(query, update, {multi: true}, onward)
         }, function(onward) {
-          if (!info.rules.iHaveMany) return onward()
+          if (!alwaysRemove && !info.rules.iHaveMany) return onward()
 
-          var orphans = {_id: { $nin: this._doc[myPath] } }
-          orphans[itsPath] = this._doc._id
+          var orphans = {_id: { $nin: doc[myPath] } }
+          orphans[itsPath] = doc._id
           info.instance.model(info.modelName).update(orphans, remove, {multi: true}, onward)
         }.bind(this)
       ], function(err, res) {
@@ -85,6 +85,7 @@ module.exports = function Relationship(info) {
   addPath()
   this.enforceWith = function(itsPath, options) {
     schema.post('save', updateDependents(itsPath))
+    schema.post('findOneAndUpdate', updateDependents(itsPath, true))
     schema.pre('remove', removeDependents(itsPath, options && options.delete))
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supergoose",
   "description": "Mongoose plugin for simple addons like findOrCreate",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "keywords": [
     "supergoose",
     "mongodb",


### PR DESCRIPTION
We aren't updating relationship dependencies when calling `findOneAndUpdate` through Mongoose. There are probably more we should capture too

Also adding an option `alwaysRemove` where we will remove potential orphan relationships. This needs to be done for _at least_ `findOneAndUpdate` (I didn't want to enable to by default until I understand more about what we're using it for)