### PR TITLE
Not all models have relationships - bail early if so

### DIFF
--- a/lib/relationship.js
+++ b/lib/relationship.js
@@ -24,7 +24,7 @@ module.exports = function Relationship(info) {
 
   function updateDependents(itsPath, alwaysRemove) {
     return function(doc, next) {
-      if (!doc) return next(null)
+      if (!doc) return next()
 
       var update = { }
       update[updateOp] = {}

--- a/lib/relationship.js
+++ b/lib/relationship.js
@@ -23,7 +23,10 @@ module.exports = function Relationship(info) {
   }
 
   function updateDependents(itsPath, alwaysRemove) {
-    return function(doc, next) {
+    return function(_doc, _next) {
+      var next = _.isFunction(_doc) ? _doc : _next;
+      var doc = !_.isFunction(_doc) ? _doc : this._doc;
+      
       var update = { }
       update[updateOp] = {}
       update[updateOp][itsPath] = doc._id

--- a/lib/relationship.js
+++ b/lib/relationship.js
@@ -24,9 +24,8 @@ module.exports = function Relationship(info) {
 
   function updateDependents(itsPath, alwaysRemove) {
     return function(_doc, _next) {
-      var next = _.isFunction(_doc) ? _doc : _next;
-      var doc = !_.isFunction(_doc) ? _doc : this._doc;
-      
+      if (!doc) return next(null)
+
       var update = { }
       update[updateOp] = {}
       update[updateOp][itsPath] = doc._id

--- a/lib/relationship.js
+++ b/lib/relationship.js
@@ -23,7 +23,7 @@ module.exports = function Relationship(info) {
   }
 
   function updateDependents(itsPath, alwaysRemove) {
-    return function(_doc, _next) {
+    return function(doc, next) {
       if (!doc) return next(null)
 
       var update = { }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supergoose",
   "description": "Mongoose plugin for simple addons like findOrCreate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "keywords": [
     "supergoose",
     "mongodb",


### PR DESCRIPTION
We added a post `findOneAndUpdate` hook to update the model's dependencies, but the side effect of this change is that _all_ models are affected, even those without dependencies. In the case of models without dependencies, the `doc` parameter isn't defined so just bail out if that's the case.